### PR TITLE
Fix compatibility of conftest.py with Astropy 3.2

### DIFF
--- a/lcps/conftest.py
+++ b/lcps/conftest.py
@@ -2,7 +2,19 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
+from astropy.version import version as astropy_version
+if astropy_version < '3.0':
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+
+from astropy.tests.helper import enable_deprecations_as_exceptions
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions


### PR DESCRIPTION
### :page_with_curl: About this pull request

Hi there :wave:, it looks like you likely used the astropy package template in the past for your package and we noticed that your conftest.py file is now out of date and imports pytest plugins from astropy:

```python
from astropy.tests.pytest_plugins import *
```

This astropy sub-package has been removed, so your tests will likely be failing now that astropy v3.2 has been released. This PR therefore fixes this import by checking the astropy version and adjusting the import as needed.

### :loudspeaker: For info: updates to the package template

We also wanted to let you know that we have made new releases of the astropy package-template. If your package still needs to support Python 2, you can find the latest [Python 2-compatible cookiecutter template here](https://github.com/astropy/package-template/tree/cookiecutter-2.x) or if you prefer you can find a [rendered version of the template here](https://github.com/astropy/package-template/tree/master-py2).

If you only need to support Python 3, you can find the latest [cookiecutter template here](https://github.com/astropy/package-template) or if you prefer you can find a [rendered version of the template here](https://github.com/astropy/package-template/tree/master).

If you need any help with updating your package to the latest package template, don't hesitate to ping @astrofrog or @bsipocz and we can try and help.

If you do not want to make this change for now, feel free to close the pull request

Thanks! :robot: :wave:

*If there are issues with this pull request, please ping ``@astrofrog``*